### PR TITLE
Refactor CLI to use a single Lunch Money client instance

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -17,15 +17,15 @@ import (
 	"github.com/urfave/cli/v3"
 )
 
-// contextKey is used as a key for storing values in context
+// contextKey is used as a key for storing values in context.
 type contextKey string
 
 const (
-	// clientContextKey is the key for storing the Lunch Money client in context
+	// clientContextKey is the key for storing the Lunch Money client in context.
 	clientContextKey contextKey = "lunchMoneyClient"
 )
 
-// getClientFromContext retrieves the Lunch Money client from context
+// getClientFromContext retrieves the Lunch Money client from context.
 func getClientFromContext(ctx context.Context) (*lm.Client, error) {
 	client, ok := ctx.Value(clientContextKey).(*lm.Client)
 	if !ok {
@@ -300,7 +300,6 @@ func createCategoriesListCommand() *cli.Command {
 
 // categoriesListAction handles the categories list CLI command.
 func categoriesListAction(ctx context.Context, c *cli.Command) error {
-	// Get Lunch Money client from context
 	lmc, err := getClientFromContext(ctx)
 	if err != nil {
 		return err

--- a/cli.go
+++ b/cli.go
@@ -17,6 +17,23 @@ import (
 	"github.com/urfave/cli/v3"
 )
 
+// contextKey is used as a key for storing values in context
+type contextKey string
+
+const (
+	// clientContextKey is the key for storing the Lunch Money client in context
+	clientContextKey contextKey = "lunchMoneyClient"
+)
+
+// getClientFromContext retrieves the Lunch Money client from context
+func getClientFromContext(ctx context.Context) (*lm.Client, error) {
+	client, ok := ctx.Value(clientContextKey).(*lm.Client)
+	if !ok {
+		return nil, errors.New("lunch money client not found in context")
+	}
+	return client, nil
+}
+
 // createRootCommand creates the root CLI command with subcommands.
 func createRootCommand() *cli.Command {
 	return &cli.Command{
@@ -37,6 +54,15 @@ func createRootCommand() *cli.Command {
 			} else {
 				log.SetLevel(log.InfoLevel)
 			}
+
+			// Create Lunch Money client and store in context
+			lmc, err := lm.NewClient(c.String("token"))
+			if err != nil {
+				return ctx, fmt.Errorf("failed to create Lunch Money client: %w", err)
+			}
+
+			// Store client in context
+			ctx = context.WithValue(ctx, clientContextKey, lmc)
 
 			return ctx, nil
 		},
@@ -148,9 +174,9 @@ func createTransactionInsertCommand() *cli.Command {
 
 // insertTransactionAction handles the transaction insert CLI command.
 func insertTransactionAction(ctx context.Context, c *cli.Command) error {
-	lmc, err := lm.NewClient(c.String("token"))
+	lmc, err := getClientFromContext(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to create Lunch Money client: %w", err)
+		return err
 	}
 
 	// Validate and parse the amount
@@ -274,10 +300,10 @@ func createCategoriesListCommand() *cli.Command {
 
 // categoriesListAction handles the categories list CLI command.
 func categoriesListAction(ctx context.Context, c *cli.Command) error {
-	// Create Lunch Money client
-	lmc, err := lm.NewClient(c.String("token"))
+	// Get Lunch Money client from context
+	lmc, err := getClientFromContext(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to create Lunch Money client: %w", err)
+		return err
 	}
 
 	// Fetch categories

--- a/main.go
+++ b/main.go
@@ -157,7 +157,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
-func rootAction(_ context.Context, c *cli.Command) error {
+func rootAction(ctx context.Context, c *cli.Command) error {
 	if c.Bool("debug") {
 		f, err := tea.LogToFileWith("lunchtui.log", "lunchtui", log.Default())
 		if err != nil {
@@ -168,7 +168,7 @@ func rootAction(_ context.Context, c *cli.Command) error {
 		log.SetLevel(log.DebugLevel)
 	}
 
-	lmc, err := lm.NewClient(c.String("token"))
+	lmc, err := getClientFromContext(ctx)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Centralize the creation of the Lunch Money client in the CLI commands to improve efficiency and maintainability. Update the command structure to store the client in context for reuse, eliminating redundant client creation while preserving existing functionality and error handling.