### PR TITLE
Add accounts list command with unified asset and plaid account support

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -45,6 +45,7 @@ func createRootCommand() *cli.Command {
 		Commands: []*cli.Command{
 			createTransactionCommand(),
 			createCategoriesCommand(),
+			createAccountsCommand(),
 		},
 		Before: func(ctx context.Context, c *cli.Command) (context.Context, error) {
 			// Setup logging if debug is enabled
@@ -280,19 +281,7 @@ func createCategoriesListCommand() *cli.Command {
 		Name:  "list",
 		Usage: "List all categories with their IDs and details",
 		Flags: []cli.Flag{
-			&cli.StringFlag{
-				Name:    "output",
-				Aliases: []string{"o"},
-				Usage:   "Output format: table or json",
-				Value:   "table",
-				Validator: func(s string) error {
-					validFormats := []string{"table", "json"}
-					if !slices.Contains(validFormats, s) {
-						return fmt.Errorf("invalid output format: %s (must be one of %v)", s, validFormats)
-					}
-					return nil
-				},
-			},
+			createOutputFormatFlag(),
 		},
 		Action: categoriesListAction,
 	}
@@ -334,7 +323,7 @@ func categoriesListAction(ctx context.Context, c *cli.Command) error {
 	}
 }
 
-// outputCategoriesJSON outputs categories in JSON format.
+// outputJSON outputs data in JSON format.
 func outputJSON(data any) error {
 	jsonData, err := json.MarshalIndent(data, "", "  ")
 	if err != nil {
@@ -345,9 +334,8 @@ func outputJSON(data any) error {
 	return nil
 }
 
-// outputCategoriesTable outputs categories in table format.
-func outputCategoriesTable(categories []*lm.Category) error {
-	// Define table styles
+// createStyledTable creates a table with the standard styling used across commands.
+func createStyledTable(headers ...string) *table.Table {
 	var (
 		purple    = lipgloss.Color("99")
 		gray      = lipgloss.Color("245")
@@ -359,8 +347,7 @@ func outputCategoriesTable(categories []*lm.Category) error {
 		evenRowStyle = cellStyle.Foreground(lightGray)
 	)
 
-	// Create table
-	t := table.New().
+	return table.New().
 		Border(lipgloss.NormalBorder()).
 		BorderStyle(lipgloss.NewStyle().Foreground(purple)).
 		StyleFunc(func(row, _ int) lipgloss.Style {
@@ -373,7 +360,30 @@ func outputCategoriesTable(categories []*lm.Category) error {
 				return oddRowStyle
 			}
 		}).
-		Headers("ID", "NAME", "DESCRIPTION", "IS INCOME", "EXCLUDE FROM BUDGET", "EXCLUDE FROM TOTALS", "IS GROUP")
+		Headers(headers...)
+}
+
+// createOutputFormatFlag creates the standard output format flag used across list commands.
+func createOutputFormatFlag() *cli.StringFlag {
+	return &cli.StringFlag{
+		Name:    "output",
+		Aliases: []string{"o"},
+		Usage:   "Output format: table or json",
+		Value:   "table",
+		Validator: func(s string) error {
+			validFormats := []string{"table", "json"}
+			if !slices.Contains(validFormats, s) {
+				return fmt.Errorf("invalid output format: %s (must be one of %v)", s, validFormats)
+			}
+			return nil
+		},
+	}
+}
+
+// outputCategoriesTable outputs categories in table format.
+func outputCategoriesTable(categories []*lm.Category) error {
+	// Create table
+	t := createStyledTable("ID", "NAME", "DESCRIPTION", "IS INCOME", "EXCLUDE FROM BUDGET", "EXCLUDE FROM TOTALS", "IS GROUP")
 
 	// Add categories to table
 	for _, category := range categories {
@@ -389,6 +399,176 @@ func outputCategoriesTable(categories []*lm.Category) error {
 			strconv.FormatBool(category.ExcludeFromBudget),
 			strconv.FormatBool(category.ExcludeFromTotals),
 			strconv.FormatBool(category.IsGroup),
+		)
+	}
+
+	// Print the table
+	fmt.Println(t)
+
+	return nil
+}
+
+// Account represents a unified account structure for both assets and plaid accounts.
+type Account struct {
+	ID              int64  `json:"id"`
+	Name            string `json:"name"`
+	Type            string `json:"type"`
+	Subtype         string `json:"subtype"`
+	Balance         string `json:"balance"`
+	Currency        string `json:"currency"`
+	InstitutionName string `json:"institution_name"`
+	Status          string `json:"status"`
+	AccountType     string `json:"account_type"` // "asset" or "plaid"
+}
+
+// convertAssetToAccount converts an Asset to the unified Account structure.
+func convertAssetToAccount(asset *lm.Asset) Account {
+	return Account{
+		ID:              asset.ID,
+		Name:            asset.Name,
+		Type:            asset.TypeName,
+		Subtype:         asset.SubtypeName,
+		Balance:         asset.Balance,
+		Currency:        asset.Currency,
+		InstitutionName: asset.InstitutionName,
+		Status:          asset.Status,
+		AccountType:     "asset",
+	}
+}
+
+// convertPlaidAccountToAccount converts a PlaidAccount to the unified Account structure.
+func convertPlaidAccountToAccount(plaidAccount *lm.PlaidAccount) Account {
+	return Account{
+		ID:              plaidAccount.ID,
+		Name:            plaidAccount.Name,
+		Type:            plaidAccount.Type,
+		Subtype:         plaidAccount.Subtype,
+		Balance:         plaidAccount.Balance,
+		Currency:        plaidAccount.Currency,
+		InstitutionName: plaidAccount.InstitutionName,
+		Status:          plaidAccount.Status,
+		AccountType:     "plaid",
+	}
+}
+
+// createAccountsCommand creates the accounts command with subcommands.
+func createAccountsCommand() *cli.Command {
+	return &cli.Command{
+		Name:  "accounts",
+		Usage: "Account management commands",
+		Commands: []*cli.Command{
+			createAccountsListCommand(),
+		},
+	}
+}
+
+// createAccountsListCommand creates the accounts list subcommand.
+func createAccountsListCommand() *cli.Command {
+	return &cli.Command{
+		Name:  "list",
+		Usage: "List all accounts (assets and plaid accounts) with their IDs and details",
+		Flags: []cli.Flag{
+			createOutputFormatFlag(),
+		},
+		Action: accountsListAction,
+	}
+}
+
+// accountsListAction handles the accounts list CLI command.
+func accountsListAction(ctx context.Context, c *cli.Command) error {
+	// Create Lunch Money client
+	lmc, err := lm.NewClient(c.String("token"))
+	if err != nil {
+		return fmt.Errorf("failed to create Lunch Money client: %w", err)
+	}
+
+	// Fetch assets and plaid accounts concurrently
+	assetsChan := make(chan []*lm.Asset, 1)
+	plaidAccountsChan := make(chan []*lm.PlaidAccount, 1)
+	errorChan := make(chan error, 2)
+
+	// Fetch assets
+	go func() {
+		assets, err := lmc.GetAssets(ctx)
+		if err != nil {
+			errorChan <- fmt.Errorf("failed to fetch assets: %w", err)
+			return
+		}
+		assetsChan <- assets
+	}()
+
+	// Fetch plaid accounts
+	go func() {
+		plaidAccounts, err := lmc.GetPlaidAccounts(ctx)
+		if err != nil {
+			errorChan <- fmt.Errorf("failed to fetch plaid accounts: %w", err)
+			return
+		}
+		plaidAccountsChan <- plaidAccounts
+	}()
+
+	// Collect results
+	var assets []*lm.Asset
+	var plaidAccounts []*lm.PlaidAccount
+	for range 2 {
+		select {
+		case assets = <-assetsChan:
+		case plaidAccounts = <-plaidAccountsChan:
+		case err := <-errorChan:
+			return err
+		}
+	}
+
+	// Convert to unified Account structure
+	var accounts []Account
+	for _, asset := range assets {
+		accounts = append(accounts, convertAssetToAccount(asset))
+	}
+	for _, plaidAccount := range plaidAccounts {
+		accounts = append(accounts, convertPlaidAccountToAccount(plaidAccount))
+	}
+
+	// Sort accounts by name for consistent output
+	sort.Slice(accounts, func(i, j int) bool {
+		return accounts[i].Name < accounts[j].Name
+	})
+
+	// Output based on format
+	switch c.String("output") {
+	case "json":
+		return outputJSON(accounts)
+	case "table":
+		return outputAccountsTable(accounts)
+	default:
+		return errors.New("unsupported output format")
+	}
+}
+
+// outputAccountsTable outputs accounts in table format.
+func outputAccountsTable(accounts []Account) error {
+	// Create table
+	t := createStyledTable("ID", "NAME", "TYPE", "SUBTYPE", "BALANCE", "CURRENCY", "INSTITUTION", "STATUS", "ACCOUNT TYPE")
+
+	// Add accounts to table
+	for _, account := range accounts {
+		subtype := account.Subtype
+		if subtype == "" {
+			subtype = "-"
+		}
+		institution := account.InstitutionName
+		if institution == "" {
+			institution = "-"
+		}
+		t.Row(
+			strconv.FormatInt(account.ID, 10),
+			account.Name,
+			account.Type,
+			subtype,
+			account.Balance,
+			account.Currency,
+			institution,
+			account.Status,
+			account.AccountType,
 		)
 	}
 

--- a/cli.go
+++ b/cli.go
@@ -476,13 +476,11 @@ func createAccountsListCommand() *cli.Command {
 
 // accountsListAction handles the accounts list CLI command.
 func accountsListAction(ctx context.Context, c *cli.Command) error {
-	// Create Lunch Money client
-	lmc, err := lm.NewClient(c.String("token"))
+	lmc, err := getClientFromContext(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to create Lunch Money client: %w", err)
+		return fmt.Errorf("getting Lunch Money client from context: %w", err)
 	}
 
-	// Fetch assets and plaid accounts concurrently
 	assetsChan := make(chan []*lm.Asset, 1)
 	plaidAccountsChan := make(chan []*lm.PlaidAccount, 1)
 	errorChan := make(chan error, 2)

--- a/cli.go
+++ b/cli.go
@@ -383,7 +383,9 @@ func createOutputFormatFlag() *cli.StringFlag {
 // outputCategoriesTable outputs categories in table format.
 func outputCategoriesTable(categories []*lm.Category) error {
 	// Create table
-	t := createStyledTable("ID", "NAME", "DESCRIPTION", "IS INCOME", "EXCLUDE FROM BUDGET", "EXCLUDE FROM TOTALS", "IS GROUP")
+	t := createStyledTable(
+		"ID", "NAME", "DESCRIPTION", "IS INCOME", "EXCLUDE FROM BUDGET", "EXCLUDE FROM TOTALS", "IS GROUP",
+	)
 
 	// Add categories to table
 	for _, category := range categories {
@@ -487,9 +489,9 @@ func accountsListAction(ctx context.Context, c *cli.Command) error {
 
 	// Fetch assets
 	go func() {
-		assets, err := lmc.GetAssets(ctx)
-		if err != nil {
-			errorChan <- fmt.Errorf("failed to fetch assets: %w", err)
+		assets, assetsError := lmc.GetAssets(ctx)
+		if assetsError != nil {
+			errorChan <- fmt.Errorf("failed to fetch assets: %w", assetsError)
 			return
 		}
 		assetsChan <- assets
@@ -497,9 +499,9 @@ func accountsListAction(ctx context.Context, c *cli.Command) error {
 
 	// Fetch plaid accounts
 	go func() {
-		plaidAccounts, err := lmc.GetPlaidAccounts(ctx)
-		if err != nil {
-			errorChan <- fmt.Errorf("failed to fetch plaid accounts: %w", err)
+		plaidAccounts, plaidAccountsErr := lmc.GetPlaidAccounts(ctx)
+		if plaidAccountsErr != nil {
+			errorChan <- fmt.Errorf("failed to fetch plaid accounts: %w", plaidAccountsErr)
 			return
 		}
 		plaidAccountsChan <- plaidAccounts
@@ -512,8 +514,8 @@ func accountsListAction(ctx context.Context, c *cli.Command) error {
 		select {
 		case assets = <-assetsChan:
 		case plaidAccounts = <-plaidAccountsChan:
-		case err := <-errorChan:
-			return err
+		case fetchError := <-errorChan:
+			return fetchError
 		}
 	}
 

--- a/main_test.go
+++ b/main_test.go
@@ -432,3 +432,76 @@ func TestFilterUncategorizedTransactions(t *testing.T) {
 		}
 	}
 }
+
+func TestConvertAssetToAccount(t *testing.T) {
+	asset := &lm.Asset{
+		ID:              123,
+		Name:            "Test Asset",
+		TypeName:        "checking",
+		SubtypeName:     "savings",
+		Balance:         "1000.00",
+		Currency:        "USD",
+		InstitutionName: "Test Bank",
+		Status:          "active",
+	}
+
+	account := convertAssetToAccount(asset)
+
+	be.Equal(t, int64(123), account.ID)
+	be.Equal(t, "Test Asset", account.Name)
+	be.Equal(t, "checking", account.Type)
+	be.Equal(t, "savings", account.Subtype)
+	be.Equal(t, "1000.00", account.Balance)
+	be.Equal(t, "USD", account.Currency)
+	be.Equal(t, "Test Bank", account.InstitutionName)
+	be.Equal(t, "active", account.Status)
+	be.Equal(t, "asset", account.AccountType)
+}
+
+func TestConvertPlaidAccountToAccount(t *testing.T) {
+	plaidAccount := &lm.PlaidAccount{
+		ID:              456,
+		Name:            "Test Plaid Account",
+		Type:            "depository",
+		Subtype:         "checking",
+		Balance:         "2500.50",
+		Currency:        "USD",
+		InstitutionName: "Plaid Bank",
+		Status:          "active",
+	}
+
+	account := convertPlaidAccountToAccount(plaidAccount)
+
+	be.Equal(t, int64(456), account.ID)
+	be.Equal(t, "Test Plaid Account", account.Name)
+	be.Equal(t, "depository", account.Type)
+	be.Equal(t, "checking", account.Subtype)
+	be.Equal(t, "2500.50", account.Balance)
+	be.Equal(t, "USD", account.Currency)
+	be.Equal(t, "Plaid Bank", account.InstitutionName)
+	be.Equal(t, "active", account.Status)
+	be.Equal(t, "plaid", account.AccountType)
+}
+
+func TestCreateOutputFormatFlag(t *testing.T) {
+	flag := createOutputFormatFlag()
+
+	be.Equal(t, "output", flag.Name)
+	be.Equal(t, "o", flag.Aliases[0])
+	be.Equal(t, 1, len(flag.Aliases))
+	be.Equal(t, "Output format: table or json", flag.Usage)
+	be.Equal(t, "table", flag.Value)
+	be.Nonzero(t, flag.Validator)
+
+	// Test validator with valid formats
+	err := flag.Validator("table")
+	be.NilErr(t, err)
+
+	err = flag.Validator("json")
+	be.NilErr(t, err)
+
+	// Test validator with invalid format
+	err = flag.Validator("invalid")
+	be.Nonzero(t, err)
+	be.True(t, strings.Contains(err.Error(), "invalid output format"))
+}


### PR DESCRIPTION
Introduce a new command to list all accounts, combining manual assets and bank-connected accounts into a unified structure. Enhance performance with concurrent fetching and maintain consistent CLI interface. Include comprehensive tests for conversion functions and validation.